### PR TITLE
refactor: early return and =None for optional parameters

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -47,20 +47,23 @@ def insert_song(song: Song):
     connection.commit()
 
 
-def delete_song(title, id):
+def delete_song(title=None, id=None):
     """deletes a song by id or title from the database"""
-    if id and title:
-        cursor.execute(
-            "DELETE FROM tunes WHERE ROWID = ? OR song_title = ?", (id, title)
-        )
-    elif id:
-        cursor.execute("DELETE FROM tunes WHERE ROWID = ?", (id,))
-    elif title:
-        cursor.execute("DELETE FROM tunes WHERE song_title = ?", (title,))
-    else:
+    if id is None and title is None:
         return
+    if id is not None and title is not None:
+        cursor.execute(
+            "DELETE FROM tunes WHERE ROWID = ? AND title = ?",
+            (id, title)
+        )
+    elif id is not None:
+        cursor.execute("DELETE FROM tunes WHERE ROWID = ?", (id,))
+    elif title is not None:
+        cursor.execute(
+            "DELETE FROM tunes WHERE song_title = ?",
+            (title,)
+        )
     connection.commit()
-
 
 app = Flask(__name__)
 


### PR DESCRIPTION
In Python, if your function has optional parameters, it is convention to include `=None`. It is a little strange in general that you could hypothetically supply no arguments, but idk, u figure that out.

Also, minor change, just moving the return to be the first condition. That's just how the people be doin it. #earlyreturn